### PR TITLE
Change crafatar to mc-heads

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <!-- Edit this to change staff cards! -->
   <script id="staff-template" type="text/template">
     <div class="staff-card shrink">
-      <img src="https://crafatar.com/avatars/{{ uuid }}">
+      <img src="https://mc-heads.net/avatar/{{ uuid }}">
       <h3>{{ name }}</h3>
       <h4>{{ rank }}</h4>
     </div>


### PR DESCRIPTION
https://crafatar.com/avatars/{{ uuid }} doesn't render head layer on the image while https://mc-heads.net/avatar/{{ uuid }} does.

Crafatar: 
![zsgh](https://user-images.githubusercontent.com/48604271/150652575-96e07027-37e0-4583-b712-044af438c7f7.png)

MC-Heads:
![YUbA](https://user-images.githubusercontent.com/48604271/150652580-b548dc7c-5743-4ddc-9bd4-8700b82c585b.png)


